### PR TITLE
Replace React.createClass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var React = require('react');
-var PropTypes = require('prop-types')
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var Immutable = require('immutable');
 var window = require('global/window');
 var document = require('global/document');
@@ -10,7 +11,7 @@ var WebGLHeatmap = require('webgl-heatmap');
 var ViewportMercator = require('viewport-mercator-project');
 var viridis = require('scale-color-perceptual/hex/viridis.json');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 
   displayName: 'HeatmapOverlay',
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "r-dom": "^2.0.0",
     "react": "0.14.x - 16.x",
     "react-dom": "0.14.x - 16.x",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "create-react-class": "^15.6.0"
   },
   "dependencies": {
     "example-cities": "0.0.0",


### PR DESCRIPTION
Like `React.propTypes`, deprecated in 15.x & removed in 16